### PR TITLE
WP-40 Create button component

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -11,6 +11,21 @@ module.exports = {
     "@storybook/addon-essentials",
     "@storybook/preset-create-react-app"
   ],
+  typescript: {
+    reactDocgen: "react-docgen-typescript",
+    reactDocgenTypescriptOptions: {
+      shouldExtractLiteralValuesFromEnum: true,
+      compilerOptions: {
+        allowSyntheticDefaultImports: false,
+        esModuleInterop: false,
+      },
+      propFilter: (prop) => {
+        return prop.parent
+            ?  prop.parent.name !== 'DOMAttributes' && prop.parent.name !== 'HTMLAttributes' && prop.parent.name !== 'AriaAttributes'
+            : true;
+      },
+    },
+  },
   // TODO: Remove the following temporary fix: https://githubmemory.com/repo/storybookjs/storybook/issues/16099?page=2
   features: { modernInlineRender: true },
   // TODO: Check and remove Storybook compatibility code once Storybook is in v7: 

--- a/src/components/Button/index.stories.tsx
+++ b/src/components/Button/index.stories.tsx
@@ -13,5 +13,6 @@ const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {
+  color: 'darkPrimary',
   children: 'Button',
 };

--- a/src/components/Button/index.stories.tsx
+++ b/src/components/Button/index.stories.tsx
@@ -5,10 +5,13 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 import Button from '.';
 
 export default {
-  title: 'Cognito/Button',
+  title: 'Components/Button',
   component: Button,
 } as ComponentMeta<typeof Button>;
 
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
 
-export const Primary = Template.bind({});
+export const Default = Template.bind({});
+Default.args = {
+  children: 'Button',
+};

--- a/src/components/Button/index.styles.ts
+++ b/src/components/Button/index.styles.ts
@@ -2,15 +2,18 @@ import { Button } from '@mui/material';
 import { ButtonProps as MUIButtonProps } from '@mui/material/Button';
 import styled from 'styled-components';
 
-interface StyledButtonProps extends Omit<MUIButtonProps, 'color'> {
-  cssColor?: string,
-  cssTextColor?: string,
+interface StyledButtonProps extends MUIButtonProps {
+  disableCaps?: boolean,
 }
 
 const StyledButton = styled(Button)<StyledButtonProps>`
   && {
-    background-color: ${({ theme, cssColor }) => cssColor || theme.palette.darkPrimary.main};
-    color: ${({ theme, cssTextColor }) => cssTextColor || theme.palette.common.white}
+    text-transform: ${({ disableCaps }) => (disableCaps ? 'none' : undefined)};
+    padding-left: 48px;
+    padding-right: 48px;
+    padding-top: 12px;
+    padding-bottom: 12px;
+    border-radius: 8px
   }
 `;
 

--- a/src/components/Button/index.styles.ts
+++ b/src/components/Button/index.styles.ts
@@ -1,9 +1,17 @@
 import { Button } from '@mui/material';
-// import { styled } from '@mui/material/styles';
+import { ButtonProps as MUIButtonProps } from '@mui/material/Button';
 import styled from 'styled-components';
 
-const StyledButton = styled(Button)`
-  color: white;
+interface StyledButtonProps extends Omit<MUIButtonProps, 'color'> {
+  cssColor?: string,
+  cssTextColor?: string,
+}
+
+const StyledButton = styled(Button)<StyledButtonProps>`
+  && {
+    background-color: ${({ theme, cssColor }) => cssColor || theme.palette.darkPrimary.main};
+    color: ${({ theme, cssTextColor }) => cssTextColor || theme.palette.common.white}
+  }
 `;
 
 export { StyledButton };

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,32 +1,25 @@
 import React from 'react';
 
 import { ButtonProps as MUIButtonProps } from '@mui/material/Button';
-import { useTheme } from 'styled-components';
 
 import { StyledButton } from './index.styles';
 
-interface ButtonProps extends Omit<MUIButtonProps, 'color'> {
-  // Background color of the button
-  color: string,
-  // Color of the button text
-  textColor: string,
+interface ButtonProps extends MUIButtonProps {
+  /**
+   * If `true`, the button text is no longer transformed
+   */
+  disableCaps?: boolean,
 }
 
-const Button = ({ variant = 'contained', color, textColor, children, ...rest }: ButtonProps) => {
-  const theme = useTheme();
-  console.log(theme);
-
-  return (
-    <StyledButton
-      variant={variant}
-      cssColor={color}
-      cssTextColor={textColor}
-      disableRipple
-      {...rest}
-    >
-      {children}
-    </StyledButton>
-  );
-};
+const Button = ({ variant = 'contained', color = 'darkPrimary', children, ...rest }: ButtonProps) => (
+  <StyledButton
+    variant={variant}
+    color={color}
+    disableRipple
+    {...rest}
+  >
+    {children}
+  </StyledButton>
+);
 
 export default Button;

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,28 +1,32 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 
-import { Typography } from '@mui/material';
+import { ButtonProps as MUIButtonProps } from '@mui/material/Button';
+import { useTheme } from 'styled-components';
 
 import { StyledButton } from './index.styles';
 
-interface ButtonProps {
-  color?: 'primary' | 'secondary';
-  variant?: 'text' | 'contained' | 'outlined';
-  size?: 'small' | 'medium' | 'large';
-  disabled?: boolean;
-  text: string;
-  onClick?: () => void;
+interface ButtonProps extends Omit<MUIButtonProps, 'color'> {
+  // Background color of the button
+  color: string,
+  // Color of the button text
+  textColor: string,
 }
 
-const Button = ({ disabled = false, color = 'primary', size = 'small', variant = 'contained', text, onClick }: ButtonProps) => (
-  <>
-    <Typography variant="h1">Hello</Typography>
-    <Typography>
-      Hello HelloHelloHelloHelloHello
-    </Typography>
-    <StyledButton disabled={disabled} color={color} size={size} variant={variant} onClick={onClick}>
-      {text}
+const Button = ({ variant = 'contained', color, textColor, children, ...rest }: ButtonProps) => {
+  const theme = useTheme();
+  console.log(theme);
+
+  return (
+    <StyledButton
+      variant={variant}
+      cssColor={color}
+      cssTextColor={textColor}
+      disableRipple
+      {...rest}
+    >
+      {children}
     </StyledButton>
-  </>
-);
+  );
+};
 
 export default Button;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -16,7 +16,7 @@ const theme = {
     },
     darkPrimary: {
       main: '#32989a',
-      dark: '#143D3E',
+      dark: '#287a7b',
       light: '#70d0d1',
       contrastText: '#fff',
     },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,19 +1,6 @@
-import { createTheme } from '@mui/material/styles';
-
-// Augment module to accept custom theme values
-// declare module '@mui/material/styles' {
-//     interface Theme {
-//       status: {
-//         danger: string;
-//       };
-//     }
-//     // allow configuration using `createTheme`
-//     interface ThemeOptions {
-//       status?: {
-//         danger?: string;
-//       };
-//     }
-//   }
+import {
+  createTheme,
+} from '@mui/material/styles';
 
 const theme = {
   spacing: 8,
@@ -26,6 +13,12 @@ const theme = {
       dark: '#32989a',
       light: '#d1eff0',
       contrastText: '#000',
+    },
+    darkPrimary: {
+      main: '#32989a',
+      dark: '#143D3E',
+      light: '#70d0d1',
+      contrastText: '#fff',
     },
     secondary: {
       main: '#345995',

--- a/src/types/mui-material/Button.d.ts
+++ b/src/types/mui-material/Button.d.ts
@@ -1,0 +1,7 @@
+import '@mui/material/Button';
+
+declare module '@mui/material/Button' {
+  export interface ButtonPropsColorOverrides {
+    darkPrimary: true;
+  }
+}

--- a/src/types/mui-material/styles.d.ts
+++ b/src/types/mui-material/styles.d.ts
@@ -3,21 +3,11 @@ import '@mui/material/styles';
 // Add more properties here as required in theme.ts
 declare module '@mui/material/styles' {
   export interface Palette {
-      darkPrimary: {
-        main: string,
-        dark: string,
-        light: string,
-        contrastText: string,
-    }
+      darkPrimary: Palette['primary'],
   }
 
   export interface PaletteOptions{
-    darkPrimary?: {
-      main?: string,
-      dark?: string,
-      light?: string,
-      contrastText?: string,
-    }
+    darkPrimary?: PaletteOptions['primary'],
   }
 
   export interface Theme {

--- a/src/types/mui-material/styles.d.ts
+++ b/src/types/mui-material/styles.d.ts
@@ -1,0 +1,30 @@
+import '@mui/material/styles';
+
+// Add more properties here as required in theme.ts
+declare module '@mui/material/styles' {
+  export interface Palette {
+      darkPrimary: {
+        main: string,
+        dark: string,
+        light: string,
+        contrastText: string,
+    }
+  }
+
+  export interface PaletteOptions{
+    darkPrimary?: {
+      main?: string,
+      dark?: string,
+      light?: string,
+      contrastText?: string,
+    }
+  }
+
+  export interface Theme {
+    palette: Palette
+  }
+
+  export interface ThemeOptions {
+    palette?: PaletteOptions
+  }
+}

--- a/src/types/mui-material/styles.d.ts
+++ b/src/types/mui-material/styles.d.ts
@@ -3,7 +3,7 @@ import '@mui/material/styles';
 // Add more properties here as required in theme.ts
 declare module '@mui/material/styles' {
   export interface Palette {
-      darkPrimary: Palette['primary'],
+    darkPrimary: Palette['primary'],
   }
 
   export interface PaletteOptions{

--- a/src/types/mui-material/styles.d.ts
+++ b/src/types/mui-material/styles.d.ts
@@ -9,12 +9,4 @@ declare module '@mui/material/styles' {
   export interface PaletteOptions{
     darkPrimary?: PaletteOptions['primary'],
   }
-
-  export interface Theme {
-    palette: Palette
-  }
-
-  export interface ThemeOptions {
-    palette?: PaletteOptions
-  }
 }

--- a/src/types/styled-components/index.d.ts
+++ b/src/types/styled-components/index.d.ts
@@ -1,0 +1,7 @@
+import 'styled-components';
+import { Theme } from '@mui/material/styles';
+
+// Extend the MUI Theme object to use the same theme defined in theme.ts for styled-components
+declare module 'styled-components' {
+  export interface DefaultTheme extends Theme{}
+}


### PR DESCRIPTION
This PR adds a type-checked `darkPrimary` theme set to the palette and adjusts storybook configurations to use such custom props.

It also configures the repository to use `styled` from `styled-components`, rather than MUI, for consistency purposes.

It also styled the button with correct storybook controls:
![image](https://user-images.githubusercontent.com/32473932/144688544-5619311e-8a1f-4b7e-bc20-de3b112634e4.png)

When `disableCaps` is `true`:
![image](https://user-images.githubusercontent.com/32473932/144688566-346566e7-1e1e-4a99-a7b4-20aaca530f1d.png)

When it is `false`:
![image](https://user-images.githubusercontent.com/32473932/144688572-60558858-b37c-43c6-9e22-c7a4d6c5076c.png)

**Known issue: `darkPrimary` does not appear as a prop option on StorybookJS - I could not figure it out, so will be creating a bug ticket in the backlog: https://cognitotuition.atlassian.net/browse/WP-45**
