### PR TITLE
NO-ISSUE Fix trailing top margin on VerificationCode

### DIFF
--- a/src/components/VerificationCode/index.styles.ts
+++ b/src/components/VerificationCode/index.styles.ts
@@ -2,16 +2,11 @@ import { Typography } from '@mui/material';
 import styled from 'styled-components';
 
 import Button from '../Button';
-import FixedLengthField from '../FixedLengthField';
 
 const StyledVerification = styled.form`
   display: flex;
   flex-direction: column;
   align-items: center;
-`;
-
-const StyledField = styled(FixedLengthField)`
-  margin: ${({ theme }) => theme.spacing(2)};
 `;
 
 const StyledButton = styled(Button)`
@@ -26,4 +21,9 @@ const FooterText = styled(Typography)`
   }
 `;
 
-export { StyledVerification, StyledButton, StyledField, FooterText };
+const FixedLengthFieldContainer = styled.div`
+  margin-bottom: ${({ theme }) => theme.spacing(2)};
+  margin-top: ${({ theme }) => theme.spacing(2)};
+`;
+
+export { StyledVerification, StyledButton, FooterText, FixedLengthFieldContainer };

--- a/src/components/VerificationCode/index.tsx
+++ b/src/components/VerificationCode/index.tsx
@@ -7,8 +7,10 @@ import {
 } from '@mui/material';
 import { useForm } from 'react-hook-form';
 
+import FixedLengthField from '../FixedLengthField';
+
 import {
-  FooterText, StyledButton, StyledField, StyledVerification,
+  FixedLengthFieldContainer, FooterText, StyledButton, StyledVerification,
 } from './index.styles';
 
 interface Data {
@@ -77,13 +79,15 @@ const VerificationCode = ({ confirm, resend, onConfirm } : VerificationCodeProps
           {errorMessage}
         </Alert>
       </Collapse>
-      <StyledField
-        error={!!errors.verification}
-        errorMessage=""
-        maxLength={6}
-        numbersOnly
-        {...register('verification', { required: true, pattern: /\d{6}/ })}
-      />
+      <FixedLengthFieldContainer>
+        <FixedLengthField
+          error={!!errors.verification}
+          errorMessage=""
+          maxLength={6}
+          numbersOnly
+          {...register('verification', { required: true, pattern: /\d{6}/ })}
+        />
+      </FixedLengthFieldContainer>
       <StyledButton type="submit" loading={loading}>
         Verify
       </StyledButton>

--- a/src/pages/SignUpPage/index.styles.ts
+++ b/src/pages/SignUpPage/index.styles.ts
@@ -58,4 +58,14 @@ const FooterText = styled(Typography)`
   }
 `;
 
-export { Title, Logo, HeaderContainer, RootContainer, Container, FooterText };
+const VerificationCodeContainer = styled.div`
+  margin-top: ${({ theme }) => theme.spacing(2)};
+`;
+
+export { Title,
+  Logo,
+  HeaderContainer,
+  RootContainer,
+  Container,
+  FooterText,
+  VerificationCodeContainer };

--- a/src/pages/SignUpPage/index.tsx
+++ b/src/pages/SignUpPage/index.tsx
@@ -16,7 +16,7 @@ import {
 } from './index.styles';
 
 const SignUpPage = () => {
-  const [step, setStep] = useState(1);
+  const [step, setStep] = useState(0);
   const [email, setEmail] = useState('');
   const navigate = useNavigate();
 

--- a/src/pages/SignUpPage/index.tsx
+++ b/src/pages/SignUpPage/index.tsx
@@ -12,11 +12,11 @@ import logo from '../../images/logo.png';
 import { confirmSignUp, resendConfirmationCode } from '../../services/auth';
 
 import {
-  Container, FooterText, HeaderContainer, Logo, RootContainer, Title,
+  Container, FooterText, HeaderContainer, Logo, RootContainer, Title, VerificationCodeContainer,
 } from './index.styles';
 
 const SignUpPage = () => {
-  const [step, setStep] = useState(0);
+  const [step, setStep] = useState(1);
   const [email, setEmail] = useState('');
   const navigate = useNavigate();
 
@@ -73,11 +73,13 @@ const SignUpPage = () => {
         <Container>
           <Typography variant="h6">Please enter the verification code</Typography>
           <Typography variant="h6">sent to your mobile device.</Typography>
-          <VerificationCode
-            confirm={async ({ verification }) => confirmSignUp(email, verification)}
-            resend={async () => resendConfirmationCode(email)}
-            onConfirm={finishSignUp}
-          />
+          <VerificationCodeContainer>
+            <VerificationCode
+              confirm={async ({ verification }) => confirmSignUp(email, verification)}
+              resend={async () => resendConfirmationCode(email)}
+              onConfirm={finishSignUp}
+            />
+          </VerificationCodeContainer>
         </Container>
       </Grid>
     </Grid>


### PR DESCRIPTION
Making the spacing a bit more optimised for the error message display:

<img width="492" alt="image" src="https://user-images.githubusercontent.com/32473932/153590171-f39c2f06-cd03-46c7-9579-099bcafe53c6.png">
