### PR TITLE
NO-ISSUE Keep focus on FixedLengthField on backspace

### DIFF
--- a/src/components/FixedLengthField/index.tsx
+++ b/src/components/FixedLengthField/index.tsx
@@ -92,8 +92,10 @@ const FixedLengthField = forwardRef((
   };
 
   const removeEditableChar = () => {
-    if (value.length > prefixLength) setValue(value.slice(0, -1));
-    proxyRef.current.focus();
+    if (value.length > prefixLength) {
+      setValue(value.slice(0, -1));
+      proxyRef.current.focus();
+    }
   };
 
   const isNum = (x: string) => !Number.isNaN(parseInt(x, 10));


### PR DESCRIPTION
Before this, pressing backspace whilst on the first tile of FixedLengthFields would remove the focus. That's not the expected behaviour for text fields, and thereby undesirable.