### PR TITLE
WP-95 remove gradYear from students table partition key

### DIFF
--- a/backend/src/api/v1/students/endpoints/getRoot.ts
+++ b/backend/src/api/v1/students/endpoints/getRoot.ts
@@ -4,15 +4,15 @@ import { getStudent } from '../utils';
 
 export default async (req: Request, res: Response) => {
   try {
-    const { params: { gradYear, studentId } } = req;
+    const { params: { studentId } } = req;
 
     const isCaller = studentId === req.context.userId;
 
-    if (gradYear && studentId) {
-      const data = await getStudent(gradYear, studentId);
+    if (studentId) {
+      const data = await getStudent(studentId);
 
       if (data) {
-        let exposedData = (({ firstName, lastName, tutorials }) =>
+        let exposedData = (({ gradYear, firstName, lastName, tutorials }) =>
           ({
             gradYear, studentId, firstName, lastName, tutorials,
           }))(data);

--- a/backend/src/api/v1/students/index.ts
+++ b/backend/src/api/v1/students/index.ts
@@ -6,6 +6,6 @@ import { getRoot } from './endpoints';
 
 const router = express.Router();
 
-router.route('/:gradYear/:studentId').get(protect(getRoot));
+router.route('/:studentId').get(protect(getRoot));
 
 export { router };

--- a/backend/src/api/v1/students/utils.ts
+++ b/backend/src/api/v1/students/utils.ts
@@ -2,11 +2,10 @@ import AWS from 'aws-sdk';
 
 const docClient = new AWS.DynamoDB.DocumentClient();
 
-export const getStudent = async (gradYear: any, studentId: any) => {
+export const getStudent = async (studentId: any) => {
   const params = {
     TableName: 'students',
     Key: {
-      gradYear: parseInt(String(gradYear), 10),
       studentId,
     },
   };

--- a/backend/src/api/v1/tutorials/endpoints/deleteRoot.ts
+++ b/backend/src/api/v1/tutorials/endpoints/deleteRoot.ts
@@ -22,7 +22,6 @@ const deleteTutorial = async (course: string, startDatetimeIdentifier: string) =
 };
 
 interface Attendee {
-  gradYear: string,
   studentId: string
 }
 
@@ -41,12 +40,12 @@ export default async (req: Request, res: Response) => {
         const { attendees } = deletedTutorial;
 
         attendees.forEach(async (attendee: Attendee) => {
-          const { gradYear, studentId } = attendee;
-          const student = await getStudent(gradYear, studentId);
+          const { studentId } = attendee;
+          const student = await getStudent(studentId);
 
           const tutorialIndex = student?.tutorials?.map((x: any) => `${x.course}#${x.startDatetimeIdentifier}`)
             .indexOf(`${course}#${startDatetimeIdentifier}`);
-          await removeTutorialFromStudent(gradYear, studentId, tutorialIndex);
+          await removeTutorialFromStudent(studentId, tutorialIndex);
         });
 
         return res.status(200).json({ message: 'Tutorial deleted' });

--- a/backend/src/api/v1/tutorials/endpoints/putBook.ts
+++ b/backend/src/api/v1/tutorials/endpoints/putBook.ts
@@ -11,14 +11,14 @@ export default async (req: Request, res: Response) => {
   try {
     const {
       params: { course, startDatetimeIdentifier },
-      body: { gradYear, studentId },
+      body: { studentId },
     } = req;
 
     if (!isStudent(req)) return res.status(401).json({ message: 'Only students may book tutorials' });
     if (req.context.userId !== studentId) return res.status(401).json({ message: 'Unauthorised action' });
 
-    if (course && startDatetimeIdentifier && gradYear && studentId) {
-      const student = await getStudent(gradYear, studentId);
+    if (course && startDatetimeIdentifier && studentId) {
+      const student = await getStudent(studentId);
       const tutorial = await getTutorial(course, startDatetimeIdentifier);
 
       if (!student) return res.status(400).json({ message: 'Student not found' });
@@ -36,7 +36,6 @@ export default async (req: Request, res: Response) => {
       }
 
       const attendeeEntry = {
-        gradYear,
         studentId,
         firstName: student?.firstName,
         lastName: student?.lastName,
@@ -62,7 +61,6 @@ export default async (req: Request, res: Response) => {
       const studentParams = {
         TableName: 'students',
         Key: {
-          gradYear: parseInt(String(gradYear), 10),
           studentId,
         },
         UpdateExpression: 'SET tutorials = list_append(tutorials, :tutorial)',

--- a/backend/src/api/v1/tutorials/utils.ts
+++ b/backend/src/api/v1/tutorials/utils.ts
@@ -28,13 +28,12 @@ export const getTutorial = async (course: any, startDatetimeIdentifier: any) => 
 };
 
 export const removeTutorialFromStudent =
-  async (gradYear: string, studentId: string, tutorialIndex: number) => {
+  async (studentId: string, tutorialIndex: number) => {
     // The standard method of using ExpressionAttributeValues to inject the
     // tutorialIndex doesn't seem to work for index values
     const params = {
       TableName: 'students',
       Key: {
-        gradYear: parseInt(String(gradYear), 10),
         studentId,
       },
       UpdateExpression: `REMOVE tutorials[${tutorialIndex}]`,

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -2132,6 +2132,11 @@ caniuse-lite@^1.0.30001280:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz#38c781ee0a90ccfe1fe7fefd00e43f5ffdcb96fd"
   integrity sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==
 
+caniuse-lite@^1.0.30001286:
+  version "1.0.30001319"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001319.tgz#eb4da4eb3ecdd409f7ba1907820061d56096e88f"
+  integrity sha512-xjlIAFHucBRSMUo1kb5D4LYgcN1M45qdKP++lhqowDpwJwGkpIRTt5qQqnhxjj1vHcI7nrJxWhCC1ATrCEBTcw==
+
 chalk@4.1.2, chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -2,11 +2,6 @@ import React from 'react';
 
 import { ProtectedPageLayout, TitleWrapper } from '../../components/PageLayout';
 import WeekCalendar from '../../components/WeekCalendar';
-import { getCurrentUserGroups } from '../../services/auth';
-
-getCurrentUserGroups().then((groups) => {
-  console.log(groups);
-});
 
 const HomePage = () => (
   <ProtectedPageLayout title="Home">

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 
 import { ProtectedPageLayout, TitleWrapper } from '../../components/PageLayout';
 import WeekCalendar from '../../components/WeekCalendar';
+import { getCurrentUserGroups } from '../../services/auth';
+
+getCurrentUserGroups().then((groups) => {
+  console.log(groups);
+});
 
 const HomePage = () => (
   <ProtectedPageLayout title="Home">

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -14,9 +14,19 @@ type AttributeCallbackFn = NodeCallback<Error, CognitoUserAttribute[]>;
 const getCurrentUser = () => getCognitoUserPool().getCurrentUser();
 
 /**
- * @returns Username of `getCurrentUser()`
+ * @returns ID/Username of `getCurrentUser()`
  */
-const getCurrentUsername = () => getCognitoUserPool().getCurrentUser()?.getUsername();
+export const getCurrentUserId = () => getCognitoUserPool().getCurrentUser()?.getUsername();
+
+/**
+ * @returns Currently authenticated user's Cognito groups
+ */
+export const getCurrentUserGroups = () => new Promise((resolve, reject) => {
+  getCurrentUser()?.getSession((err: Error, session: any) => {
+    if (err) reject(err);
+    else resolve(session?.idToken?.payload['cognito:groups']);
+  });
+});
 
 /**
  * @returns Currently authenticated user's access token
@@ -112,7 +122,7 @@ export const signIn = async (
  * Removes the AWS Cognito account from the local storage
  */
 export const signOut = async () => {
-  const username = await getCurrentUsername();
+  const username = await getCurrentUserId();
 
   if (username) {
     return getCognitoUser(username)?.signOut();
@@ -124,7 +134,7 @@ export const signOut = async () => {
  * Invalidates all session tokens associated with an AWS Cognito account
  */
 export const globalSignOut = async () => {
-  const username = await getCurrentUsername();
+  const username = await getCurrentUserId();
 
   if (username) {
     return new Promise((resolve, reject) => {
@@ -144,7 +154,7 @@ export const globalSignOut = async () => {
  * @param newPassword
  */
 export const changePassword = async (oldPassword: string, newPassword: string) => {
-  const username = await getCurrentUsername();
+  const username = await getCurrentUserId();
 
   if (username) {
     return new Promise<void>((resolve, reject) => {

--- a/src/services/tutorials/types.ts
+++ b/src/services/tutorials/types.ts
@@ -1,7 +1,6 @@
 export type Student = {
   studentId: string,
   firstName: string,
-  gradYear: number
 }
 
 export type Tutorial = {


### PR DESCRIPTION
This PR:
- Removes `gradYear` as a key in the students table
- Exposes the function, `getCurrentUserId` for the user ID and the promise, `getCurrentUserGroups` to the rest of the frontend.

Use:
<img width="324" alt="image" src="https://user-images.githubusercontent.com/32473932/159403021-52d407f7-8aac-447b-b310-647978f76e79.png">
